### PR TITLE
Implement optimal parallel architecture for guide scanning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ version = "0.1.0"
 dependencies = [
  "bio",
  "clap",
+ "crossbeam-channel",
  "flate2",
  "lazy_static",
  "rand 0.9.0",
@@ -385,6 +386,15 @@ checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,4 @@ rand = { version = "0.9.0", features = ["small_rng"] }
 rayon = "1.10.0"
 flate2 = "1.1.0"
 lazy_static = "1.4"
+crossbeam-channel = "0.5"


### PR DESCRIPTION
## Summary
Major performance improvement that eliminates the straggler problem by parallelizing over (guide, contig) pairs instead of processing guides sequentially.

### Key Changes
- **Add support for multiple guides** via `--guides-file` option (complements existing `-g` option)
- **Global thread pool** with work-stealing across all (guide, contig) task pairs
- **Arc-wrapped shared contig data** - loaded once, no duplication
- **Single output consumer thread** prevents stdout interleaving
- **All (guide, contig) pairs** processed as independent work units

### Performance Benefits
- ✅ No synchronization barriers between guides
- ✅ Optimal load balancing - no idle threads waiting for slow contigs  
- ✅ Smooth progress without stragglers blocking the work queue
- ✅ Better CPU utilization across all cores

### Architecture
**Before:**
```
Guide1 → [all contigs in parallel] → WAIT for slowest
Guide2 → [all contigs in parallel] → WAIT for slowest
Guide3 → [all contigs in parallel] → WAIT for slowest
```

**After:**
```
Work queue: [(guide1, contig1), (guide1, contig2), ..., (guide2, contig1), ...]
                          ↓
              Global thread pool (work-stealing)
                          ↓
              Single output consumer thread → stdout
```

### Testing
Tested successfully with:
- Single guide mode: `crisprapido -r test.fa -g ATCGATCGATCGATCGATCG`
- Multiple guide mode: `crisprapido -r test_multi.fa --guides-file guides.txt`
- 3 guides × 5 contigs = all 15 task pairs processed correctly

### Technical Details
- Added `crossbeam-channel` dependency for producer-consumer pattern
- Nested parallel iteration: `guides.par_iter()` × `contigs.par_iter()`  
- New `OutputHit` struct for thread-safe result passing
- Backward compatible: existing `-g` flag still works

### Breaking Changes
None - fully backward compatible with existing command-line interface.