### PR TITLE
perf: switch from Dna to Iupac profile for native N handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,8 +1090,8 @@ dependencies = [
 
 [[package]]
 name = "sassy"
-version = "0.1.8"
-source = "git+https://github.com/RagnarGrootKoerkamp/sassy?branch=master#5799b49fa7e71402a78a8d8363d2d157e8ca44e9"
+version = "0.1.9"
+source = "git+https://github.com/RagnarGrootKoerkamp/sassy?branch=master#c31fee51e14f5798f0c0f3b241579194bb09b222"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ edition = "2021"
 [features]
 debug = []
 
+[[bench]]
+name = "dna_vs_iupac"
+harness = false
+
 [dependencies]
 sassy = { git = "https://github.com/RagnarGrootKoerkamp/sassy", branch = "master" }
 clap = { version = "4.5.37", features = ["derive"] }

--- a/benches/dna_vs_iupac.rs
+++ b/benches/dna_vs_iupac.rs
@@ -1,0 +1,95 @@
+//! Benchmark comparing Dna vs Iupac profile performance
+//! Run with: cargo bench --bench dna_vs_iupac
+
+use std::time::Instant;
+use rand::{SeedableRng, RngCore, rngs::SmallRng};
+use sassy::Searcher;
+use sassy::profiles::{Dna, Iupac};
+
+fn generate_random_seq_with_ns(rng: &mut SmallRng, length: usize, n_frequency: f64) -> Vec<u8> {
+    let bases = b"ACGT";
+    (0..length)
+        .map(|_| {
+            if (rng.next_u32() as f64 / u32::MAX as f64) < n_frequency {
+                b'N'
+            } else {
+                bases[rng.next_u32() as usize % 4]
+            }
+        })
+        .collect()
+}
+
+fn replace_ns_with_a(seq: &[u8]) -> Vec<u8> {
+    seq.iter()
+        .map(|&b| if b == b'N' { b'A' } else { b })
+        .collect()
+}
+
+fn main() {
+    let mut rng = SmallRng::seed_from_u64(42);
+
+    // Generate test data: 10MB sequence with ~1% Ns (realistic for genomic data)
+    let seq_len = 10_000_000;
+    let n_freq = 0.01;
+    let target_with_ns = generate_random_seq_with_ns(&mut rng, seq_len, n_freq);
+    let target_no_ns = replace_ns_with_a(&target_with_ns);
+
+    let n_count = target_with_ns.iter().filter(|&&b| b == b'N').count();
+    println!("Sequence length: {} bp", seq_len);
+    println!("N count: {} ({:.2}%)", n_count, 100.0 * n_count as f64 / seq_len as f64);
+
+    // Generate guide (no Ns)
+    let guide = b"ATCGATCGATCGATCGATCG"; // 20bp guide
+
+    let max_errors = 4;
+    let iterations = 10;
+
+    println!("\nBenchmarking {} iterations with max_errors={}...\n", iterations, max_errors);
+
+    // Benchmark Dna profile (requires N->A conversion)
+    let mut dna_searcher: Searcher<Dna> = Searcher::new(false, None);
+    let start = Instant::now();
+    let mut dna_matches = 0;
+    for _ in 0..iterations {
+        let results = dna_searcher.search(guide, &target_no_ns, max_errors);
+        dna_matches = results.len();
+    }
+    let dna_time = start.elapsed();
+    println!("Dna profile (with N->A conversion):");
+    println!("  Total time: {:?}", dna_time);
+    println!("  Per iteration: {:?}", dna_time / iterations);
+    println!("  Matches found: {}", dna_matches);
+
+    // Benchmark Iupac profile (native N support)
+    let mut iupac_searcher: Searcher<Iupac> = Searcher::new(false, None);
+    let start = Instant::now();
+    let mut iupac_matches = 0;
+    for _ in 0..iterations {
+        let results = iupac_searcher.search(guide, &target_with_ns, max_errors);
+        iupac_matches = results.len();
+    }
+    let iupac_time = start.elapsed();
+    println!("\nIupac profile (native N handling):");
+    println!("  Total time: {:?}", iupac_time);
+    println!("  Per iteration: {:?}", iupac_time / iterations);
+    println!("  Matches found: {}", iupac_matches);
+
+    // Compare
+    let speedup = iupac_time.as_secs_f64() / dna_time.as_secs_f64();
+    println!("\n--- Comparison ---");
+    if speedup > 1.0 {
+        println!("Dna is {:.2}x faster than Iupac", speedup);
+    } else {
+        println!("Iupac is {:.2}x faster than Dna", 1.0 / speedup);
+    }
+
+    // Also benchmark the N->A conversion overhead
+    let start = Instant::now();
+    for _ in 0..iterations {
+        let _ = replace_ns_with_a(&target_with_ns);
+    }
+    let conversion_time = start.elapsed();
+    println!("\nN->A conversion overhead:");
+    println!("  Total time: {:?}", conversion_time);
+    println!("  Per iteration: {:?}", conversion_time / iterations);
+}


### PR DESCRIPTION
## Summary
- Replace `Searcher<Dna>` with `Searcher<Iupac>` for **1.22x speedup**
- Remove N→A conversion workaround and `n_positions` bitvector tracking
- Simplify `ContigData` struct (~30 lines removed)
- Ns are now handled natively by SASSY and preserved in output

## Benchmark results (10MB sequence, 1% Ns)
| Profile | Time per iteration |
|---------|-------------------|
| Dna + N→A conversion | 6.88ms |
| Iupac (native) | 5.63ms |

## Why this works
The `Iupac` profile in SASSY supports IUPAC nucleotide codes including N (which matches any base). Previously we had to:
1. Convert all Ns to As before searching
2. Track original N positions in a bitvector
3. Restore Ns in the output

Now SASSY handles Ns directly, which is both faster and simpler.

## Test plan
- [x] All tests pass
- [x] Verified Ns preserved in output: `ts:Z:ATCGATCGATCGATCGNTCG`
- [x] Benchmark included in `benches/dna_vs_iupac.rs`