### PR TITLE
Handle ambiguous Ns in CFD scoring

### DIFF
--- a/src/cfd_score.rs
+++ b/src/cfd_score.rs
@@ -119,9 +119,17 @@ pub fn calculate_cfd(spacer: &str, protospacer: &str, pam: &str) -> Result<f64, 
                     score *= penalty;
                 },
                 None => {
-                    println!("    Pos {}: {} ≠ {} -> key: '{}' -> KEY NOT FOUND -> score = 0.0", 
-                             i+1, spacer_nt, proto_nt, key);
-                    return Ok(0.0); // Unknown mismatch gets score 0
+                    // Unknown mismatch (often due to IUPAC ambiguity like 'N');
+                    // treat as neutral mismatch with zero penalty rather than
+                    // spamming stdout and forcing the score to zero.
+                    eprintln!(
+                        "Warning: Unrecognized mismatch key '{}' at position {} ({} vs {}). Treating as score 1.",
+                        key,
+                        i + 1,
+                        spacer_nt,
+                        proto_nt
+                    );
+                    continue;
                 }
             }
         }

--- a/tests/cfd_tests.rs
+++ b/tests/cfd_tests.rs
@@ -84,6 +84,18 @@ fn test_pam_effects() {
     }
 }
 
+#[test]
+fn test_terminal_ns_are_neutral() {
+    cfd_score::init_score_matrices("mismatch_scores.txt", "pam_scores.txt")
+        .expect("Failed to initialize scoring matrices");
+
+    let spacer = "CACACAGGTCCAAAGGCGGG";
+    let target = "NNNNNNNNNNNNNNNNNNGG";
+
+    let score = cfd_score::calculate_cfd(spacer, target, "GG").unwrap();
+    assert_eq!(score, 1.0, "Ambiguous Ns at distal end should not penalize score");
+}
+
 /// Test CIGAR-based calculation matches direct calculation
 #[test]
 fn test_cigar_matches_direct() {


### PR DESCRIPTION
## Summary
- avoid logging and penalties when guides align to ambiguous bases so they no longer zero scores
- add regression test covering terminal N tracts in targets
- keep existing tests green via 
running 8 tests
test cfd_score::cfd_unit_tests::test_prepare_aligned_sequences ... ok
test cfd_score::cfd_unit_tests::test_case_insensitivity ... ok
test cfd_score::cfd_unit_tests::test_gaps_at_other_positions_have_penalties ... ok
test cfd_score::cfd_unit_tests::test_position_1_gap_no_penalty ... ok
test cfd_score::cfd_unit_tests::test_t_u_equivalence ... ok
test cfd_score::cfd_unit_tests::test_pam_effects ... ok
test cfd_score::cfd_unit_tests::test_perfect_match ... ok
test cfd_score::cfd_unit_tests::test_scores_in_valid_range ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 20 tests
test cfd_score::cfd_unit_tests::test_prepare_aligned_sequences ... ok
test tests::test_handles_ns_in_guide ... ok
test tests::test_hit_quality_scoring_and_filtering ... ok
test tests::test_handles_ns_in_target ... ok
test tests::test_normalize_cigar ... ok
test tests::test_perfect_match_sassy ... ok
test tests::test_too_many_differences_sassy ... ok
test tests::test_perfect_match_with_flanks_sassy ... ok
test tests::test_with_bulge_sassy ... ok
test tests::test_too_many_differences_with_flanks_sassy ... ok
test tests::test_with_mismatches_sassy ... ok
test tests::test_with_bulge_and_flanks_sassy ... ok
test tests::test_with_mismatches_and_flanks_sassy ... ok
test cfd_score::cfd_unit_tests::test_case_insensitivity ... ok
test cfd_score::cfd_unit_tests::test_position_1_gap_no_penalty ... ok
test cfd_score::cfd_unit_tests::test_perfect_match ... ok
test cfd_score::cfd_unit_tests::test_t_u_equivalence ... ok
test cfd_score::cfd_unit_tests::test_pam_effects ... ok
test cfd_score::cfd_unit_tests::test_gaps_at_other_positions_have_penalties ... ok
test cfd_score::cfd_unit_tests::test_scores_in_valid_range ... ok

test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 6 tests
test test_case_sensitivity ... ok
test test_perfect_matches_with_various_pams ... ok
test test_gaps_at_other_positions ... ok
test test_gap_at_position_1 ... ok
test test_cigar_based_cfd ... ok
test test_cfd_against_python_reference ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 5 tests
test test_cigar_gap_handling ... ok
test test_cigar_matches_direct ... ok
test test_pam_effects ... ok
test test_terminal_ns_are_neutral ... ok
test test_positional_effects ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
