### PR TITLE
Handle ambiguous hits and PAMs

### DIFF
--- a/tests/cfd_tests.rs
+++ b/tests/cfd_tests.rs
@@ -66,6 +66,8 @@ fn test_pam_effects() {
         ("TG", 0.038961038999999996),  // Non-canonical
         ("CG", 0.107142857),           // Non-canonical
         ("AT", 0.0),                   // Non-functional
+        ("NGG", 1.0),                  // 3nt PAM should collapse to GG
+        ("NAG", 0.25925925899999996),  // 3nt variant matching AG penalty
     ];
 
     for (pam, expected_score) in pams {


### PR DESCRIPTION
## Summary
- skip reporting guide/target hits overlapping ambiguous bases by default with an opt-in flag
- add CFD tolerance for 3nt PAM strings like NGG by collapsing to their core
- tighten tests around N handling and PAM scoring so edge cases stay stable
