### PR TITLE
Add reverse-strand scanning with CFD fixes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -981,6 +981,10 @@ fn main() {
                 seq[start..end].to_vec()
             };
 
+            if !args.include_ambiguous && target_seq.iter().any(|&b| is_ambiguous_base(b)) {
+                continue;
+            }
+
             let output_hit = OutputHit {
                 ref_id: record_id.to_string(),
                 pos,
@@ -1018,6 +1022,10 @@ fn main() {
                 let slice = &seq[start..end];
                 reverse_complement(slice)
             };
+
+            if !args.include_ambiguous && target_seq.iter().any(|&b| is_ambiguous_base(b)) {
+                continue;
+            }
 
             let adjusted_cigar = reverse_cigar(&cigar);
 


### PR DESCRIPTION
## Summary
- scan every guide on both genome strands and align reverse hits back to forward orientation for CFD scoring
- add reverse-CIGAR rewriting and reverse-complemented target slices so reverse matches reuse the original guide sequence
- skip ambiguous target slices unless --include-ambiguous is set to avoid N-only hits