### PR TITLE
restore unbounded output channel for max CPU

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use bio::io::fasta;
 use clap::Parser;
-use crossbeam_channel::bounded;
+use crossbeam_channel::unbounded;
 use flate2::read::MultiGzDecoder;
 use rayon::prelude::*;
 use sassy::profiles::Iupac;
@@ -1172,41 +1172,28 @@ fn main() {
     eprintln!("Loaded {} contig(s)", contigs.len());
 
     // Create channel for sending hits from workers to output thread
-    // Depth is configurable so callers can tune throughput/backpressure
-    let channel_depth = args.channel_depth.max(1024);
-    let (tx, rx) = bounded::<OutputHit>(channel_depth);
+    let (tx, rx) = unbounded::<OutputHit>();
     let perf_for_writer = perf_counters.clone();
 
     // Spawn single output consumer thread with buffered output
     let contigs_for_writer = contigs.clone();
     let guides_for_writer = guides.clone();
     let pam_for_writer = args.pam.clone();
-
-    let worker_count = rayon::current_num_threads().max(1);
-    let writer_threads = worker_count.min(4);
-    let rx = Arc::new(rx);
-    let writers: Vec<_> = (0..writer_threads)
-        .map(|_| {
-            let rx = rx.clone();
-            let guides = guides_for_writer.clone();
-            let contigs = contigs_for_writer.clone();
-            let pam = pam_for_writer.clone();
-            let perf = perf_for_writer.clone();
-            thread::spawn(move || {
-                let stdout = std::io::stdout();
-                let writer = stdout.lock();
-                let mut writer =
-                    CountingWriter::new(BufWriter::with_capacity(256 * 1024, writer), perf);
-                while let Ok(hit) = rx.recv() {
-                    hit.write_output(&mut writer, &guides, &contigs, &pam);
-                    if let Some(perf) = &writer.perf {
-                        perf.record_hit_written();
-                    }
-                }
-                writer.flush().expect("Failed to flush output");
-            })
-        })
-        .collect();
+    let output_thread = thread::spawn(move || {
+        let stdout = std::io::stdout();
+        let writer = stdout.lock();
+        let mut writer = CountingWriter::new(
+            BufWriter::with_capacity(256 * 1024, writer),
+            perf_for_writer,
+        );
+        for hit in rx {
+            hit.write_output(&mut writer, &guides_for_writer, &contigs_for_writer, &pam_for_writer);
+            if let Some(perf) = &writer.perf {
+                perf.record_hit_written();
+            }
+        }
+        writer.flush().expect("Failed to flush output");
+    });
 
     // Create flat list of all (guide_idx, contig_idx) task pairs
     // This eliminates nested parallelism and barriers
@@ -1349,10 +1336,8 @@ fn main() {
     // Drop the original sender to signal completion
     drop(tx);
 
-    // Wait for output threads to finish writing all results
-    for handle in writers {
-        handle.join().expect("Output thread panicked");
-    }
+    // Wait for output thread to finish writing all results
+    output_thread.join().expect("Output thread panicked");
 
     if let Some(stop) = perf_stop.as_ref() {
         stop.store(true, Ordering::Relaxed);


### PR DESCRIPTION
## Summary
- drop the bounded crossbeam channel and multi-writer pool so worker threads never block on output, restoring the original 100% CPU behavior
- keep the telemetry + buffer reuse in place so we can revisit memory limits later
- cargo test passes (warnings only)