### PR TITLE
Fix SASSY constructor breakage

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -805,7 +805,7 @@ fn convert_to_minimap2_cigar(cigar: &str) -> String {
 // Thread-local SASSY searcher to avoid repeated allocation
 // Using Iupac profile for native N handling (faster than Dna + N->A conversion)
 thread_local! {
-    static SEARCHER: RefCell<Searcher<Iupac>> = RefCell::new(Searcher::new(false, None));
+    static SEARCHER: RefCell<Searcher<Iupac>> = RefCell::new(Searcher::new(false, None, Default::default()));
 }
 
 fn scan_contig_sassy(


### PR DESCRIPTION
## Summary
- update the thread-local `Searcher` to pass the new pattern-tiling argument introduced upstream in SASSY
- ensure installs/builds succeed again now that `Searcher::new` requires the tiling configuration