### PR TITLE
Handle latest SASSY API change

### DIFF
--- a/benches/dna_vs_iupac.rs
+++ b/benches/dna_vs_iupac.rs
@@ -54,7 +54,7 @@ fn main() {
     );
 
     // Benchmark Dna profile (requires N->A conversion)
-    let mut dna_searcher: Searcher<Dna> = Searcher::new(false, None);
+    let mut dna_searcher: Searcher<Dna> = Searcher::new(false, None, Default::default());
     let start = Instant::now();
     let mut dna_matches = 0;
     for _ in 0..iterations {
@@ -68,7 +68,7 @@ fn main() {
     println!("  Matches found: {}", dna_matches);
 
     // Benchmark Iupac profile (native N support)
-    let mut iupac_searcher: Searcher<Iupac> = Searcher::new(false, None);
+    let mut iupac_searcher: Searcher<Iupac> = Searcher::new(false, None, Default::default());
     let start = Instant::now();
     let mut iupac_matches = 0;
     for _ in 0..iterations {

--- a/benches/dna_vs_iupac.rs
+++ b/benches/dna_vs_iupac.rs
@@ -54,7 +54,7 @@ fn main() {
     );
 
     // Benchmark Dna profile (requires N->A conversion)
-    let mut dna_searcher: Searcher<Dna> = Searcher::new(false, None, Default::default());
+    let mut dna_searcher: Searcher<Dna> = Searcher::new_fwd();
     let start = Instant::now();
     let mut dna_matches = 0;
     for _ in 0..iterations {
@@ -68,7 +68,7 @@ fn main() {
     println!("  Matches found: {}", dna_matches);
 
     // Benchmark Iupac profile (native N support)
-    let mut iupac_searcher: Searcher<Iupac> = Searcher::new(false, None, Default::default());
+    let mut iupac_searcher: Searcher<Iupac> = Searcher::new_fwd();
     let start = Instant::now();
     let mut iupac_matches = 0;
     for _ in 0..iterations {

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,7 +630,7 @@ fn convert_to_minimap2_cigar(cigar: &str) -> String {
 // Thread-local SASSY searcher to avoid repeated allocation
 // Using Iupac profile for native N handling (faster than Dna + N->A conversion)
 thread_local! {
-    static SEARCHER: RefCell<Searcher<Iupac>> = RefCell::new(Searcher::new(false, None, Default::default()));
+    static SEARCHER: RefCell<Searcher<Iupac>> = RefCell::new(Searcher::new_fwd());
 }
 
 fn scan_contig_sassy(

--- a/src/main.rs
+++ b/src/main.rs
@@ -630,7 +630,7 @@ fn convert_to_minimap2_cigar(cigar: &str) -> String {
 // Thread-local SASSY searcher to avoid repeated allocation
 // Using Iupac profile for native N handling (faster than Dna + N->A conversion)
 thread_local! {
-    static SEARCHER: RefCell<Searcher<Iupac>> = RefCell::new(Searcher::new(false, None));
+    static SEARCHER: RefCell<Searcher<Iupac>> = RefCell::new(Searcher::new(false, None, Default::default()));
 }
 
 fn scan_contig_sassy(


### PR DESCRIPTION
## Summary
- switch our thread-local searcher and benchmark constructors to  so builds succeed with the newest  commit that now requires a pattern-tiling searcher argument
- no behavioral logic changes beyond matching the upstream API update

## Testing
- cargo test
